### PR TITLE
better required handling

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -133,7 +133,7 @@
 
       scope.$on('angucomplete-alt:changeInput', function (event, elementId, newval) {
         if (!!elementId && elementId === scope.id) {
-          handleInputChange(newval);
+          handleInputChange(newval, true);
         }
       });
 
@@ -150,7 +150,7 @@
             }
           }
 
-          handleRequired(initial);
+          handleRequired(!!initial);
         }
       }
 


### PR DESCRIPTION
Initial was undefined when using changeInput event and form was pending (not $valid or $invalid). Now it is assumed that required is ok when changeInput is used.